### PR TITLE
Update SaeAssetManager.php

### DIFF
--- a/SaeAssetManager.php
+++ b/SaeAssetManager.php
@@ -417,7 +417,7 @@ class SaeAssetManager extends Component
 	{
 		$dir = $this->hash($src . filemtime($src));
 		$dstDir = $this->basePath . DIRECTORY_SEPARATOR . $dir;
-		if (!empty($options['forceCopy']) || ($this->forceCopy && !isset($options['forceCopy'])) || !$this->saeIsDir($dstDir)) {
+		if (!empty($options['forceCopy']) || ($this->forceCopy && !isset($options['forceCopy'])) || !$this->saeIsDir($dir)) {
 			$opts = [
 			'dirMode' => $this->dirMode,
 			'fileMode' => $this->fileMode,


### PR DESCRIPTION
将420 行 $dstDir 修改为 $dir 。
如果是 $dstDir  的话，$this->saeIsDir 返回的都是0，文件夹实际是存在的，但是判断文件夹都是不存在的，所以没一次都会生成覆盖之前的文件夹，导致脚本运行会很慢。
